### PR TITLE
Add old version 4.2.10782

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.4.1" %}
+{% set version = "4.2.10782" %}
 
 package:
   name: pyomo
@@ -7,19 +7,17 @@ package:
 source:
   fn: Pyomo-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/P/Pyomo/Pyomo-{{ version }}.tar.gz
-  md5: bbd554f64178c619098dc00a09263999
+  md5: 1e1598d87d7fed4f7b9e5d0bc5b846eb
 
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - runbenders=pyomo.pysp.benders:Benders_main
-    - evaluate_xhat=pyomo.pysp.evaluate_xhat:EvaluateXhat_main
     - runph=pyomo.pysp.phinit:PH_main
     - runef=pyomo.pysp.ef_writer_script:main
     - pysp2smps=pyomo.pysp.smps.pysp2smps:main
     - phsolverserver=pyomo.pysp.phsolverserver:main
-    - scenariotreeserver=pyomo.pysp.scenariotree.server_pyro:main
     - computeconf=pyomo.pysp.computeconf:main
     - results_schema=pyomo.scripting.commands:results_schema
     - pyro_mip_server=pyomo.scripting.pyro_mip_server:main
@@ -38,7 +36,7 @@ requirements:
   build:
     - python
     - setuptools
-    - pyutilib >=5.4
+    - pyutilib >=5.2
     - appdirs
     - ply
     - six >=1.4
@@ -46,7 +44,7 @@ requirements:
   run:
     - python
     - setuptools
-    - pyutilib >=5.4
+    - pyutilib >=5.2
     - appdirs
     - ply
     - six >=1.4
@@ -107,7 +105,6 @@ test:
     - pyomo.opt.tests
     - pyomo.opt.tests.base
     - pyomo.opt.tests.blackbox
-    - pyomo.opt.tests.solver
     - pyomo.pysp
     - pyomo.pysp.plugins
     - pyomo.pysp.scenariotree
@@ -144,12 +141,10 @@ test:
 
   commands:
     - runbenders --help
-    - evaluate_xhat --help
     - runph --help
     - runef --help
     - pysp2smps --help
     - phsolverserver --help
-    - scenariotreeserver --help
     - computeconf --help
     - test.pyomo --help
     - pyomo --help


### PR DESCRIPTION
Required to build `calliope` on conda-forge: https://github.com/conda-forge/staged-recipes/pull/1795

Probably this should go into a separate branch so master keeps pointing to the most recent version?
